### PR TITLE
feat: support airplanes.live API key for commercial use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0   # need full history + tags so we can compare against the latest release tag
 
       - name: Bump version
         id: bump
@@ -36,15 +37,29 @@ jobs:
         run: |
           # Extract current version from build.gradle
           CURRENT_VERSION=$(grep "^version = " build.gradle | sed "s/version = '\(.*\)'/\1/")
-          echo "Current version: $CURRENT_VERSION"
+          echo "Current version in build.gradle: $CURRENT_VERSION"
 
-          # Parse version components
+          # Find the most recent v*.*.* release tag (sorted by semver, not lexically).
+          # Empty string if no tags exist yet — treat that as "older than anything".
+          git fetch --tags --quiet || true
+          LATEST_TAG=$(git tag --list 'v*.*.*' | sed 's/^v//' | sort -V | tail -n 1)
+          echo "Latest released tag version: ${LATEST_TAG:-<none>}"
+
+          # If the human (or another commit) has already bumped build.gradle ahead of the
+          # latest release tag, skip the auto-bump and release the version as-is.
+          # `sort -V` gives semver ordering; the highest of {gradle, tag} wins the tail.
+          HIGHEST=$(printf '%s\n%s\n' "$CURRENT_VERSION" "${LATEST_TAG:-0.0.0}" | sort -V | tail -n 1)
+          if [ "$CURRENT_VERSION" != "${LATEST_TAG:-0.0.0}" ] && [ "$HIGHEST" = "$CURRENT_VERSION" ]; then
+            echo "build.gradle ($CURRENT_VERSION) is ahead of latest tag (${LATEST_TAG:-<none>}) — skipping auto-bump."
+            echo "new_version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Otherwise, gradle matches (or trails) the latest tag — do the normal patch bump.
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-
-          # Increment patch version
           NEW_PATCH=$((PATCH + 1))
           NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
-          echo "New version: $NEW_VERSION"
+          echo "Bumping patch: $CURRENT_VERSION -> $NEW_VERSION"
 
           # Update build.gradle
           sed -i "s/version = '${CURRENT_VERSION}'/version = '${NEW_VERSION}'/" build.gradle

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ radius: 250
 # Seconds until CoT marker becomes stale
 staleTimeSec: 30
 
+# Optional airplanes.live API key (REQUIRED for commercial/production use)
+# apiKey: "your-api-key-here"
+# apiKeyHeader: "auth"   # or "X-RapidAPI-Key" if using RapidAPI
+
 # Optional: TAK groups to publish to
 # groups:
 #   - "__ANON__"
@@ -135,6 +139,8 @@ staleTimeSec: 30
 | `longitude` | -81.0348 | Center point longitude |
 | `radius` | 250 | Query radius in nautical miles (max 250) |
 | `staleTimeSec` | 30 | Seconds until marker becomes stale |
+| `apiKey` | (none) | airplanes.live API key. Optional for personal/research use, **required for commercial use** |
+| `apiKeyHeader` | `auth` | HTTP header name used to send the API key (e.g. `X-RapidAPI-Key` for RapidAPI) |
 | `groups` | (all) | List of TAK groups to publish to |
 
 ## API Rate Limits
@@ -146,6 +152,23 @@ The airplanes.live API has the following limits:
 At the default 5-second interval, you'll use approximately 17,280 requests per day. Consider:
 - Increasing the interval for long-term monitoring
 - Using a paid API tier for production deployments
+
+## API Key (Required for Commercial / Production Use)
+
+The plugin defaults to airplanes.live's free public endpoint, which is intended for **personal, research, and non-commercial use only**. If you intend to run this plugin in a commercial, operational, or production environment, you **must** obtain an API key from airplanes.live and configure it in `tak.server.plugins.AdsbPlugin.yaml`:
+
+```yaml
+apiKey: "your-api-key-here"
+apiKeyHeader: "auth"      # or "X-RapidAPI-Key" when using RapidAPI
+```
+
+How to get a key:
+- **RapidAPI (commercial plans)** — see [airplanes.live commercial use](https://airplanes.live/commercial-use/). When using a RapidAPI key, set `apiKeyHeader: "X-RapidAPI-Key"`.
+- **Direct commercial agreement** — contact airplanes.live via the email listed on their commercial use page. Use whatever header name they specify (defaults to `auth`).
+
+When `apiKey` is set the plugin attaches it to every outbound request via the configured header. When it is blank or omitted the plugin falls back to the free public endpoint. The key value is never written to logs; only its presence and header name are logged at startup.
+
+Operating commercially against the public endpoint without a license violates the airplanes.live terms of service — see the [Data Use Disclaimer](#data-use-disclaimer) below.
 
 ## Verification
 
@@ -239,9 +262,9 @@ The proxy configuration is logged at startup when detected.
 
 ## Data Use Disclaimer
 
-This project uses data from the airplanes.live API. The airplanes.live ADS-B data is provided for non-commercial, research, and demonstration purposes only. Any commercial use of airplanes.live data requires a proper license obtained directly from airplanes.live. By using this software, you agree to comply with the airplanes.live terms of service and all applicable data use restrictions.
+This project uses data from the airplanes.live API. The airplanes.live ADS-B data is provided for non-commercial, research, and demonstration purposes only. **Any commercial or production use of airplanes.live data requires a properly licensed API key obtained directly from airplanes.live** (see [API Key](#api-key-required-for-commercial--production-use) above). By using this software, you agree to comply with the airplanes.live terms of service and all applicable data use restrictions.
 
-This tool is intended for personal research, education, and demonstration use cases such as situational awareness prototyping and TAK integration development. It is not intended for operational, commercial, or safety-of-life applications.
+This tool is intended for personal research, education, and demonstration use cases such as situational awareness prototyping and TAK integration development. It is not intended for operational, commercial, or safety-of-life applications without an appropriate commercial license from airplanes.live.
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'tak.server.plugins'
-version = '1.0.4'
+version = '1.1.0'
 
 // Java 17 for compatibility with TAK Server runtime
 sourceCompatibility = '17'

--- a/src/main/java/tak/server/plugins/AdsbPlugin.java
+++ b/src/main/java/tak/server/plugins/AdsbPlugin.java
@@ -62,6 +62,8 @@ import atakmap.commoncommo.protobuf.v1.MessageOuterClass.Message;
  * longitude: -81.0348      # Center point longitude
  * radius: 250              # Query radius in nm (max 250)
  * staleTimeSec: 30         # Seconds until CoT marker becomes stale
+ * apiKey: ""               # Optional airplanes.live API key (required for commercial use)
+ * apiKeyHeader: "auth"     # Header name used to send the API key (override for RapidAPI etc.)
  * groups:                  # TAK groups to publish to
  *   - "__ANON__"
  */
@@ -80,6 +82,7 @@ public class AdsbPlugin extends MessageSenderBase {
     private static final int DEFAULT_RADIUS = 75;
     private static final int DEFAULT_STALE_TIME_SEC = 30;
     private static final int MAX_RADIUS = 250;
+    private static final String DEFAULT_API_KEY_HEADER = "auth";
 
     private final ScheduledExecutorService worker = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> future;
@@ -93,6 +96,8 @@ public class AdsbPlugin extends MessageSenderBase {
     private final Set<String> groups;
     private final String pluginId;
     private final HttpHost proxy;
+    private final String apiKey;
+    private final String apiKeyHeader;
 
     private final AtomicInteger totalMessagesSent = new AtomicInteger(0);
     private final AtomicInteger totalPollCycles = new AtomicInteger(0);
@@ -134,6 +139,23 @@ public class AdsbPlugin extends MessageSenderBase {
             this.staleTimeSec = DEFAULT_STALE_TIME_SEC;
         }
 
+        // API key is optional but required for commercial use of the airplanes.live API.
+        // Normalize first so whitespace-padded or literal "null" YAML values are treated as unset.
+        if (config.containsProperty("apiKey")) {
+            String configKey = String.valueOf(config.getProperty("apiKey")).trim();
+            this.apiKey = (configKey.isEmpty() || configKey.equalsIgnoreCase("null")) ? null : configKey;
+        } else {
+            this.apiKey = null;
+        }
+
+        if (config.containsProperty("apiKeyHeader")) {
+            String configHeader = String.valueOf(config.getProperty("apiKeyHeader")).trim();
+            this.apiKeyHeader = (configHeader.isEmpty() || configHeader.equalsIgnoreCase("null"))
+                ? DEFAULT_API_KEY_HEADER : configHeader;
+        } else {
+            this.apiKeyHeader = DEFAULT_API_KEY_HEADER;
+        }
+
         if (config.containsProperty("groups")) {
             Object groupsConfig = config.getProperty("groups");
             this.groups = new HashSet<>();
@@ -156,6 +178,7 @@ public class AdsbPlugin extends MessageSenderBase {
         logger.info("  Radius: {} nm", radius);
         logger.info("  Stale time: {} sec", staleTimeSec);
         logger.info("  Groups: {}", groups.isEmpty() ? "(all)" : groups);
+        logger.info("  API key: {}", apiKey == null ? "(none — free tier)" : "configured (header: " + apiKeyHeader + ")");
         if (proxy != null) {
             logger.info("  Proxy: {}:{}", proxy.getHostName(), proxy.getPort());
         }
@@ -208,6 +231,9 @@ public class AdsbPlugin extends MessageSenderBase {
                 API_BASE, latitude, longitude, radius);
 
             HttpGet request = new HttpGet(url);
+            if (apiKey != null) {
+                request.setHeader(apiKeyHeader, apiKey);
+            }
             logger.debug("Fetching: {}", url);
 
             httpClient.execute(request, response -> {

--- a/tak.server.plugins.AdsbPlugin.yaml
+++ b/tak.server.plugins.AdsbPlugin.yaml
@@ -21,6 +21,19 @@ radius: 75
 # Recommended: slightly longer than polling interval
 staleTimeSec: 30
 
+# airplanes.live API key (optional for personal/research use, REQUIRED for
+# commercial or production use per airplanes.live terms of service).
+# Obtain a key from https://airplanes.live/commercial-use/ (RapidAPI) or by
+# contacting airplanes.live directly for a commercial agreement.
+# Leave blank/commented out to use the free public endpoint.
+# apiKey: "your-api-key-here"
+
+# Header name used to send the API key. Defaults to "auth".
+# Common overrides:
+#   - "X-RapidAPI-Key"  (when using RapidAPI commercial plans)
+#   - "Authorization"   (if airplanes.live issues a Bearer-style key)
+# apiKeyHeader: "auth"
+
 # TAK groups to publish aircraft to (optional)
 # If not specified or empty, messages go to all groups
 # groups:


### PR DESCRIPTION
Adds optional apiKey and apiKeyHeader config options so deployments with a commercial airplanes.live license can authenticate their requests. Defaults preserve free-tier behavior (no auth header) and the key value is kept out of logs. README and YAML now document the commercial-use requirement per airplanes.live terms of service.